### PR TITLE
feat(tags): tag-origin back navigation (Option B)

### DIFF
--- a/apps/blog/static/blog/js/board_state.js
+++ b/apps/blog/static/blog/js/board_state.js
@@ -296,6 +296,10 @@ Board state manager
     const hasCountry = !!boardContent.querySelector("[data-has-country='1']");
     if (hasCountry) return true;
 
+    // ✅ Legacy/compat marker: tags board can announce itself
+    const hasTags = !!boardContent.querySelector("[data-has-tags='1']");
+    if (hasTags) return true;
+
     // ✅ New marker: non-country boards (tags etc.)
     const boardOpen = !!boardContent.querySelector("[data-board-open='1']");
     if (boardOpen) return true;

--- a/apps/blog/templates/blog/_board.html
+++ b/apps/blog/templates/blog/_board.html
@@ -139,8 +139,8 @@
   <div class="toc">
     {% for p in posts %}
       <a class="toc-link {% if selected_post and selected_post.slug == p.slug %}active{% endif %}"
-         href="/{{ selected_country.slug }}/{{ selected_category_slug }}/{{ p.slug }}/?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}"
-         hx-get="/{{ selected_country.slug }}/{{ selected_category_slug }}/{{ p.slug }}/?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}"
+         href="/{{ selected_country.slug }}/{{ selected_category_slug }}/{{ p.slug }}/?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}{% if from_tags %}&src=tags&from_tag={{ from_tag|urlencode }}&from_page={{ from_page }}{% if from_q %}&from_q={{ from_q|urlencode }}{% endif %}{% endif %}"
+         hx-get="/{{ selected_country.slug }}/{{ selected_category_slug }}/{{ p.slug }}/?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}{% if from_tags %}&src=tags&from_tag={{ from_tag|urlencode }}&from_page={{ from_page }}{% if from_q %}&from_q={{ from_q|urlencode }}{% endif %}{% endif %}"
          hx-target="#boardContent"
          hx-swap="innerHTML"
          hx-indicator=".htmx-indicator"
@@ -198,13 +198,23 @@
 
   {% if selected_post %}
     <div class="pager">
-      <a class="btn pager-back js-back"
-         href="{{ category_path }}?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}"
-         hx-get="{{ category_path }}?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}"
-         hx-target="#boardContent"
-         hx-swap="innerHTML"
-         hx-indicator=".htmx-indicator"
-         hx-push-url="true">목록</a>
+      {% if from_tags and tags_back_url %}
+        <a class="btn pager-back js-back"
+           href="{{ tags_back_url }}"
+           hx-get="{{ tags_back_url }}"
+           hx-target="#boardContent"
+           hx-swap="innerHTML"
+           hx-indicator=".htmx-indicator"
+           hx-push-url="true">목록</a>
+      {% else %}
+        <a class="btn pager-back js-back"
+           href="{{ category_path }}?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}"
+           hx-get="{{ category_path }}?page={% if page_obj %}{{ page_obj.number }}{% else %}1{% endif %}{% if q %}&q={{ q|urlencode }}{% endif %}{% if tag %}&tag={{ tag|urlencode }}{% endif %}{% if sort and sort != 'new' %}&sort={{ sort|urlencode }}{% endif %}"
+           hx-target="#boardContent"
+           hx-swap="innerHTML"
+           hx-indicator=".htmx-indicator"
+           hx-push-url="true">목록</a>
+      {% endif %}
 
       {% if page_obj and page_obj.paginator.num_pages > 1 %}
         <div class="pager-nav">

--- a/apps/blog/templates/blog/_board_tags.html
+++ b/apps/blog/templates/blog/_board_tags.html
@@ -2,6 +2,8 @@
 
 <div data-has-country="0" hidden></div>
 <div data-has-post="0" hidden></div>
+<div data-board-open="1" hidden></div>
+<div data-has-tags="1" hidden></div>
 
 <div class="board-sticky">
   <div class="board-header">
@@ -65,8 +67,8 @@
   <div class="tags-posts">
     {% for p in posts %}
       <a class="tag-post-link"
-         href="{{ p.get_absolute_url }}"
-         hx-get="{{ p.get_absolute_url }}"
+         href="{{ p.get_absolute_url }}?src=tags&from_tag={{ selected_tag.slug|urlencode }}&from_page={{ page_obj.number }}{% if q %}&from_q={{ q|urlencode }}{% endif %}"
+         hx-get="{{ p.get_absolute_url }}?src=tags&from_tag={{ selected_tag.slug|urlencode }}&from_page={{ page_obj.number }}{% if q %}&from_q={{ q|urlencode }}{% endif %}"
          hx-target="#boardContent"
          hx-swap="innerHTML"
          hx-indicator=".htmx-indicator"


### PR DESCRIPTION
## 요약 (Summary)
- 컨텍스트 기반 "목록으로 돌아가기" 동작(옵션 B)을 구현했습니다.
- `/tags/<tag>/`에서 게시물 상세로 진입한 경우, 상세 화면의 **“목록”** 버튼이 해당 태그 상세 목록으로 복귀합니다.
- 국가/카테고리 경로에서 진입한 경우, **“목록”** 동작은 기존과 동일하게 카테고리 목록으로 복귀합니다.

## 유지한 핵심 규칙 (Key Rules Preserved)
- 보드 껍데기(`#board`)는 고정, **`#boardContent`만** HTMX로 swap 합니다.
- Network 기준: 보드 내 이동 중 **Document(Doc) 요청은 0**을 유지합니다.
- `board_state.js`는 SSOT를 유지하며, `popstate`에서 `#boardContent`를 재로딩하지 않습니다(콘텐츠 복원은 HTMX history + board_state 담당).

## 변경 사항 (Changes)
- `views.py`: tag 컨텍스트 전달 + `tag_not_found` 처리 추가
- `_board_tags.html`: 상세 진입 링크에 `src=tags&from_tag&from_page(&from_q)` 컨텍스트 전파
- `_board.html`: `from_tags`일 때만 “목록” 버튼이 `tags_back_url`로 분기
- `board_state.js`: `data-board-open` / `data-has-tags` 기반으로 국가 없이도 보드 열림 상태 지원

## 테스트 체크리스트 (Test Checklist)
- [x] `/tags/` → 태그 상세 → 게시물 상세 → “목록” 클릭 시 `/tags/<tag>/?page=...`로 복귀
- [x] 국가/카테고리 → 게시물 상세 → “목록” 클릭 시 기존처럼 카테고리 목록으로 복귀
- [x] DevTools Network: 보드 내 이동 중 Document(Doc) 요청 = 0
- [x] 모바일: dim 탭 닫기 / edge swipe close 정상
- [x] offline/online: 에러 오버레이 노출 + 재시도(스모크) 정상
