### PR TITLE
fix(search): prevent Document navigation on country search Enter (Doc 0)

### DIFF
--- a/apps/blog/static/blog/js/search_ux.js
+++ b/apps/blog/static/blog/js/search_ux.js
@@ -120,10 +120,19 @@
       }
 
       if (e.key === "Enter") {
-        // 활성 항목이 있으면 그 국가로 이동
+        // ✅ Doc 요청 방지: HTMX 링크면 클릭 이벤트로 트리거해서 XHR로 처리
         const target = links[activeIdx] || vis[0];
         if (target && target.href) {
           e.preventDefault();
+
+          // hx-get이 있거나 htmx가 로드되어 있으면 "클릭"을 발생시켜 htmx가 가로채게 한다.
+          if (window.htmx && (target.getAttribute("hx-get") || target.hasAttribute("data-hx-get"))) {
+            const evt = new MouseEvent("click", { bubbles: true, cancelable: true, view: window });
+            target.dispatchEvent(evt);
+            return;
+          }
+
+          // fallback: htmx가 없거나 hx 속성이 없으면 일반 이동
           window.location.href = target.href;
         }
       }


### PR DESCRIPTION
## 요약
- 홈 화면의 **국가 검색창에서 Enter로 국가 선택 시** 전체 문서 이동(Document 요청)이 발생하던 문제를 수정했습니다.
- Enter 선택도 HTMX 경로로 처리되어 **보드만 부분 갱신(#boardContent swap)** 되며, Network에서 **Doc 요청 0**을 유지합니다.

## 유지한 핵심 규칙
- `#board`는 고정, `#boardContent`만 HTMX로 swap
- 보드 내 네비게이션 중 Document(Doc) 요청 = 0
- `board_state.js` SSOT / history(popstate) 안정성 원칙 유지

## 변경 사항
- `apps/blog/static/blog/js/search_ux.js`
  - Enter 키 처리 시 `window.location`(문서 이동) 대신, **국가 링크 click 이벤트를 발생**시켜 HTMX가 가로채도록 변경
  - (fallback) HTMX가 없거나 hx 속성이 없는 경우에만 기존 문서 이동 사용

## 테스트 체크리스트
- [x] 홈에서 국가 검색 → Enter 선택 시 Network Document(Doc) 요청 = 0
- [x] 국가 보드가 전체 리로드 없이 열리고, URL은 정상적으로 변경됨(hx-push-url)
- [x] 기존 클릭 선택/검색 필터/ESC 동작에 영향 없음(스모크)
- [x] 모바일에서도 동일하게 동작(스모크)

## 롤백(문제 시)
```bash
git fetch origin
git switch main
git reset --hard origin/main
git clean -fd
