### PR TITLE
ux(tags): preserve tag-detail context when clicking tag chips in post detail

### DIFF
--- a/apps/blog/templates/blog/_board.html
+++ b/apps/blog/templates/blog/_board.html
@@ -323,18 +323,37 @@
       {% if selected_post.tags.exists %}
         <div class="post-tags" aria-label="Post tags" style="margin-top:16px;">
           {% for t in selected_post.tags.all %}
-            <a class="tag-chip-link"
-               href="/tags/{{ t.slug }}/"
-               hx-get="/tags/{{ t.slug }}/"
-               hx-target="#boardContent"
-               hx-swap="innerHTML"
-               hx-indicator=".htmx-indicator"
-               hx-push-url="true">
-              <span class="tag-chip">#{{ t.name }}</span>
-            </a>
+            {% if from_tags %}
+              {# 태그에서 들어온 상세면: 태그 상세 진입에도 컨텍스트 유지 #}
+              <a class="tag-chip-link"
+                 href="/tags/{{ t.slug|urlencode }}/?page={{ from_page|default:'1' }}{% if from_q %}&q={{ from_q|urlencode }}{% endif %}{% if from_sort and from_sort != 'new' %}&sort={{ from_sort|urlencode }}{% endif %}"
+                 hx-get="/tags/{{ t.slug|urlencode }}/?page={{ from_page|default:'1' }}{% if from_q %}&q={{ from_q|urlencode }}{% endif %}{% if from_sort and from_sort != 'new' %}&sort={{ from_sort|urlencode }}{% endif %}"
+                 hx-target="#boardContent"
+                 hx-swap="innerHTML"
+                 hx-indicator=".htmx-indicator"
+                 hx-push-url="true">
+                <span class="tag-chip">#{{ t.name }}</span>
+              </a>
+            {% else %}
+              {# 일반 상세면: 단순 이동(기존 동작 유지) #}
+              <a class="tag-chip-link"
+                 href="/tags/{{ t.slug|urlencode }}/"
+                 hx-get="/tags/{{ t.slug|urlencode }}/"
+                 hx-target="#boardContent"
+                 hx-swap="innerHTML"
+                 hx-indicator=".htmx-indicator"
+                 hx-push-url="true">
+                <span class="tag-chip">#{{ t.name }}</span>
+              </a>
+            {% endif %}
           {% endfor %}
         </div>
       {% endif %}
+
+      
+      
+      
+      
 
 
     </div>


### PR DESCRIPTION
## 요약
- 게시물 상세 하단의 태그 칩 클릭 시, 태그에서 진입한 컨텍스트(페이지/검색/정렬)를 유지한 채 태그 상세로 이동하도록 개선했습니다.
- 태그에서 진입한 상세(`from_tags`)에서만 동작하며, 국가/카테고리 흐름은 기존 동작을 유지합니다.

## 유지한 핵심 규칙
- `#board` 고정, `#boardContent`만 HTMX swap
- 보드 내 이동 중 Network Document(Doc) 요청 = 0
- `board_state.js` SSOT 및 history 안정성 원칙 유지
- `_board.html`의 `data-has-*` 마커 규칙 유지

## 변경 사항
- `apps/blog/templates/blog/_board.html`
  - `from_tags` 컨텍스트가 있는 경우에만 태그 칩 링크에 `page/q/sort`를 전달
  - 일반 상세에서는 `/tags/<slug>/`로 단순 이동(기존 동작 유지)

## 테스트 체크리스트
- [x] `/tags/<tag>/`에서 검색/정렬/페이지 설정 → 글 상세 진입
- [x] 상세 하단 태그 칩 클릭 → 태그 상세로 이동하면서 `page/q/sort` 유지
- [x] 태그 상세 → 글 상세 → “목록” 복귀 시 원래 태그 상세 상태 유지
- [x] 국가/카테고리 → 글 상세에서 태그 칩 클릭: 기존 동작 유지
- [x] DevTools Network: Document(Doc) 요청 = 0

## 롤백(문제 시)
```bash
git fetch origin
git switch main
git reset --hard origin/main
git clean -fd