### PR TITLE
ui(post): compact wrap layout for post detail tag chips

### DIFF
--- a/apps/blog/static/blog/css/site.css
+++ b/apps/blog/static/blog/css/site.css
@@ -1094,3 +1094,19 @@ html.board-open body {
     pointer-events: auto;
   }
 }
+/* Post detail tag chips: compact wrap layout (scoped) */
+.post-tags--wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+  align-items: flex-start;
+}
+
+.post-tags--wrap .tag-chip,
+.post-tags--wrap a.tag-chip {
+  display: inline-flex !important;
+  width: auto !important;
+  margin: 0 !important;
+  white-space: nowrap;
+}

--- a/apps/blog/templates/blog/_board.html
+++ b/apps/blog/templates/blog/_board.html
@@ -319,10 +319,10 @@
         </div>
       {% endif %}
 
-      {# ✅ 태그: 글 맨 아래(갤러리 아래) #}
-      {% if selected_post.tags.exists %}
-        <div class="post-tags" aria-label="Post tags" style="margin-top:16px;">
-          {% for t in selected_post.tags.all %}
+      {# ✅ 태그: 글 맨 아래(갤러리 아래) / ✅ 정렬+중복제거는 view에서 post_tags로 처리 #}
+      {% if post_tags %}
+        <div class="post-tags post-tags--wrap" aria-label="Post tags">
+          {% for t in post_tags %}
             {% if from_tags %}
               {# 태그에서 들어온 상세면: 태그 상세 진입에도 컨텍스트 유지 #}
               <a class="tag-chip-link"
@@ -349,12 +349,6 @@
           {% endfor %}
         </div>
       {% endif %}
-
-      
-      
-      
-      
-
 
     </div>
   {% else %}


### PR DESCRIPTION
## 요약
- 게시물 상세 하단 태그 칩의 레이아웃을 가로 배치 + 자동 줄바꿈 형태로 개선했습니다.
- 태그 간격을 축소해 “한 줄에 하나씩” 떨어지는 문제를 해소했습니다.

## 유지한 핵심 규칙
- `#board` 고정, `#boardContent`만 HTMX swap
- 보드 내 이동 중 Network Document(Doc) 요청 = 0
- `board_state.js` SSOT / history 안정성 유지
- 기존 보드 내 네비게이션(목록/이전/다음 등) 로직 변경 없음

## 변경 사항
- `_board.html`: 태그 컨테이너에 전용 클래스(`post-tags--wrap`) 추가
- CSS: `.post-tags--wrap` 범위에만 적용되는 flex-wrap + gap + width/margin 보정 추가

## 테스트 체크리스트
- [x] 태그 3개 이상 글 상세에서 가로 배치 + 자동 줄바꿈 확인
- [x] 태그 클릭 이동/목록/이전/다음 동작 기존대로 정상
- [x] DevTools Network: Document(Doc) 요청 = 0
- [x] 모바일에서도 태그 간격/줄바꿈 정상

## 롤백(문제 시)
```bash
git fetch origin
git switch main
git reset --hard origin/main
git clean -fd