### PR TITLE
ui(board): normalize link color to prevent visited purple/blue

### DIFF
--- a/apps/blog/static/blog/css/site.css
+++ b/apps/blog/static/blog/css/site.css
@@ -1110,3 +1110,16 @@ html.board-open body {
   margin: 0 !important;
   white-space: nowrap;
 }
+/* ========== Board-wide link color normalization ==========
+   Goal: prevent default blue/purple link colors (including :visited)
+   Scope: only inside the board (#board)
+   Note: uses :where() to keep specificity low (won't break button/tab styles that set their own color)
+*/
+:where(#board) a,
+:where(#board) a:visited,
+:where(#board) a:hover,
+:where(#board) a:active,
+:where(#board) a:focus {
+  color: inherit;
+  text-decoration: none;
+}


### PR DESCRIPTION
## 요약
- 보드 영역(#board) 내부의 링크 색상을 통일해, 기본 링크 파란색/방문 링크 보라색(:visited) 문제가 다시 발생하지 않도록 처리했습니다.
- 태그 보드(검색/정렬/페이지네이션 포함), 게시물 상세 하단 태그 칩 등 보드 내 모든 클릭 가능한 링크에 일괄 적용됩니다.

## 변경 사항
- `site.css`: `:where(#board) a`, `a:visited` 등 보드 영역 링크 색상을 `inherit`로 고정

## 테스트 체크리스트
- [x] 태그 상세에서 글 클릭 후 목록 복귀 시 보라색(visited) 미발생
- [x] 태그 검색/정렬 후에도 링크 색상 유지
- [x] 게시물 상세 하단 태그 칩 클릭 후에도 링크 색상 유지
- [x] 보드 내 이동 중 Network Document(Doc) 요청 = 0

## 롤백
```bash
git fetch origin
git switch main
git reset --hard origin/main
git clean -fd