### PR TITLE
docs(ops): add runbooks for tag slug changes and mirror backups

### DIFF
--- a/docs/runbook_backup_mirrors.md
+++ b/docs/runbook_backup_mirrors.md
@@ -1,0 +1,62 @@
+# Runbook: GitLab/Bitbucket 수동 백업(미러 대체)
+
+## 목적
+- GitHub(origin)의 “검증된 기준점”을 수동으로 백업한다.
+- 자동 미러링(매 push마다) 대신, 안전한 타이밍에만 수행한다.
+- GitLab은 main 보호(Protected Branch)로 force push가 불가하므로,
+  날짜 기반 backup 브랜치로 GitHub main을 보관한다.
+
+## 백업 타이밍(원칙)
+- merge → Render 배포 완료 → 스모크 테스트 완료 → snapshot 태그 생성/푸시 완료 직후
+- 추가로 권장하는 시점:
+  - 마이그레이션/라우팅/CI 변경 등 큰 변경이 포함된 배포 직후
+  - 대형 리팩터링 착수 직전
+
+## 원격(remote) 전제
+- origin = GitHub
+- gitlab = GitLab
+- bitbucket = Bitbucket
+- 확인:
+  - git remote -v
+
+## 표준 백업 절차(PowerShell)
+### 0) GitHub main 최신화
+- 로컬에서 실행:
+  - git switch main
+  - git fetch origin --prune --tags
+  - git pull --ff-only
+
+### 1) Bitbucket: main + tags 동기화
+- Bitbucket은 main을 GitHub main과 동일하게 유지한다.
+  - git push bitbucket origin/main:main
+  - git push bitbucket --tags
+
+### 2) GitLab: backup 브랜치로 GitHub main 보관 + tags 동기화
+- GitLab은 main이 보호될 수 있으므로 backup 브랜치를 사용한다.
+  - $stamp = Get-Date -Format "yyyy-MM-dd"
+  - git push gitlab origin/main:refs/heads/backup/github-main-$stamp
+  - git push gitlab --tags
+
+### 3) 확인(필수)
+- Bitbucket main이 origin/main과 같은지:
+  - git ls-remote --heads bitbucket main
+  - git ls-remote --heads origin main
+  - 해시가 동일하면 OK
+- GitLab backup 브랜치가 생성됐는지:
+  - git ls-remote --heads gitlab "backup/github-main-$stamp"
+- snapshot 태그가 양쪽에 존재하는지:
+  - git ls-remote --tags bitbucket "snapshot/*"
+  - git ls-remote --tags gitlab "snapshot/*"
+
+## 주의사항
+- GitLab에서 MR(merge request) 생성 링크가 떠도 정상이다.
+  - backup 브랜치는 보관 목적이므로 MR을 만들 필요 없다.
+- GitLab main을 강제 동기화하려면:
+  - Protected Branch 정책 변경이 필요하며 실수 리스크가 있으므로 기본 정책은 “하지 않음”.
+
+## 기록(운영 로그)
+- 백업 수행 날짜
+- 기준 snapshot 태그명
+- Bitbucket main 해시
+- GitLab backup 브랜치명
+을 운영 로그(ELN/Notion)에 남긴다.

--- a/docs/runbook_tag_slug_changes.md
+++ b/docs/runbook_tag_slug_changes.md
@@ -1,0 +1,72 @@
+# Runbook: Tag slug 변경 운영 절차 (TagSlugHistory + Redirect)
+
+## 목적
+- Tag slug가 변경되더라도 기존 주소(/tags/<old>/)가 깨지지 않게 유지한다.
+- old slug로 접근 시 canonical slug(/tags/<new>/)로 리다이렉트된다.
+- HTMX 요청에서도 보드 UX를 유지한다(204 + HX-Redirect).
+
+## 사전 조건
+- 배포는 GitHub main merge 이후 Render 자동 배포로 진행한다.
+- 배포 후 스모크 테스트 및 snapshot 태그를 반드시 남긴다.
+
+## 핵심 동작(정의)
+- Tag slug 변경 시, 시스템은 old slug를 TagSlugHistory로 보존한다.
+- /tags/<old>/ 접근:
+  - 일반 요청: 301 → /tags/<new>/ (쿼리스트링 유지)
+  - HTMX 요청: 204 + HX-Redirect: /tags/<new>/ (쿼리스트링 유지)
+- Unicode slug(예: 온천)도 지원하며, 헤더/Location은 ASCII(퍼센트 인코딩) 형태로 정규화된다.
+
+## 변경 방법(권장)
+### A) Django admin에서 변경
+1. Admin에서 Tag 선택
+2. slug 변경(필요 시 name도 함께 정합성 맞춤)
+3. 저장 후 확인:
+   - TagSlugHistory에 old_slug 기록이 생성되어야 한다(자동 생성 로직이 있는 경우)
+   - (가능하면) old slug로 접근 시 리다이렉트되는지 확인
+
+### B) 운영 DB에서 직접 수정 금지(원칙)
+- 운영 DB 직접 UPDATE로 slug를 바꾸는 것은 지양한다.
+- 반드시 admin 또는 검증된 관리 커맨드를 통해 변경한다.
+
+## 배포 전 체크(로컬)
+- 테스트:
+  - python manage.py test
+- 콘텐츠 감사(선택/권장):
+  - python manage.py audit_content --verbose --sample 50
+
+## 배포 후 체크(운영, 스모크)
+1. 태그 인덱스:
+   - /tags/ 200 OK
+2. canonical slug:
+   - /tags/<new>/ 200 OK
+3. old slug 리다이렉트(데이터가 존재하는 경우에만 검증 가능):
+   - /tags/<old>/ → /tags/<new>/ 301 OK
+   - 쿼리스트링 유지 확인: ?q=x&page=2&sort=old 등
+4. HTMX 동작(가능하면):
+   - 태그 보드에서 이동/로딩 정상
+   - old slug가 존재하면 204 + HX-Redirect 동작
+5. Render shell(권장):
+   - python manage.py audit_content --verbose --sample 50
+   - issues 0 ✅ 확인
+
+## 문제 발생 시(트러블슈팅)
+### 1) old slug 접근이 404
+- TagSlugHistory에 해당 old_slug가 존재하는지 확인
+- 존재하지 않으면:
+  - slug 변경이 admin 외부에서 발생했거나, history 생성 로직이 누락됐을 가능성
+- 우선 조치:
+  - 최근 변경 내역/커밋 확인
+  - 필요하면 hotfix로 history 생성 로직 보완 후 재배포
+
+### 2) Unicode slug에서 Location/HX-Redirect가 깨짐
+- 헤더/리다이렉트 URL이 iri_to_uri 기준으로 정규화되는지 확인
+- 테스트가 이를 고정하고 있어야 한다(회귀 방지)
+
+## 롤백
+- 원칙: “배포/스모크 완료한 snapshot 태그” 단위로 롤백 판단
+- 방법:
+  - GitHub에서 해당 PR revert → merge → Render 자동 배포 → 스모크
+  - 또는 직전 snapshot 태그 기준으로 상태 복구(필요 시)
+
+## 기록(운영 로그)
+- slug 변경을 수행한 날짜/대상 Tag/old→new를 운영 로그(ELN/Notion)에 남긴다.


### PR DESCRIPTION
## What / Why
- 태그 slug 변경 운영 절차(runbook)를 문서로 고정했습니다.
- GitLab/Bitbucket 수동 백업 절차(runbook)를 문서로 고정했습니다.
- 목적은 운영 사고(슬러그 변경/백업 누락/절차 혼선) 예방과 회귀 방지입니다.

## Changes
- docs/runbook_tag_slug_changes.md 추가
- docs/runbook_backup_mirrors.md 추가
- README.md에 runbook 링크 추가

## How to test (local)
- python manage.py test

## Risk & rollback
- 문서 변경만 포함(런타임 영향 없음)
- 롤백: PR revert

## Post-merge checklist
- Render 배포 로그 정상(문서 변경이므로 영향 없음)
- README의 runbook 링크가 GitHub에서 정상 열림